### PR TITLE
Fix dashboard API proxy and error handling

### DIFF
--- a/api/cards.ts
+++ b/api/cards.ts
@@ -1,26 +1,53 @@
 export default async function handler(req: Request): Promise<Response> {
-  const backend = process.env.BACKEND_URL
-  const user = process.env.API_USER
-  const pass = process.env.API_PASS
+  try {
+    if (req.method && req.method !== "GET") {
+      return Response.json({ error: "Método não permitido" }, { status: 405 })
+    }
 
-  if (!backend || !user || !pass) {
-    return Response.json(
-      { error: "Env BACKEND_URL/API_USER/API_PASS não configuradas" },
-      { status: 500 }
-    )
+    const backend = process.env.BACKEND_URL
+    const user = process.env.API_USER
+    const pass = process.env.API_PASS
+
+    if (!backend || !user || !pass) {
+      return Response.json(
+        { error: "Env BACKEND_URL/API_USER/API_PASS não configuradas" },
+        { status: 500 }
+      )
+    }
+
+    const url = new URL(req.url)
+    const auth = Buffer.from(`${user}:${pass}`).toString("base64")
+    const controller = new AbortController()
+    const timeoutId = setTimeout(() => controller.abort(), 8000)
+
+    try {
+      const r = await fetch(
+        `${backend}/api/dashboard/cards${url.search}`,
+        {
+          headers: { Authorization: `Basic ${auth}` },
+          signal: controller.signal,
+        }
+      )
+
+      const contentType = r.headers.get("content-type") ?? "application/json"
+      const body = await r.text()
+
+      return new Response(body, {
+        status: r.status,
+        headers: { "Content-Type": contentType },
+      })
+    } catch (error) {
+      const message =
+        error instanceof Error ? error.message : "Erro ao chamar backend"
+      const status = message.includes("aborted") ? 504 : 502
+
+      return Response.json({ error: message }, { status })
+    } finally {
+      clearTimeout(timeoutId)
+    }
+  } catch (error) {
+    const message =
+      error instanceof Error ? error.message : "Erro inesperado"
+    return Response.json({ error: message }, { status: 500 })
   }
-
-  const auth = btoa(`${user}:${pass}`)
-
-  const r = await fetch(`${backend}/api/dashboard/cards`, {
-    headers: { Authorization: `Basic ${auth}` },
-  })
-
-  const contentType = r.headers.get("content-type") ?? "application/json"
-  const body = await r.text()
-
-  return new Response(body, {
-    status: r.status,
-    headers: { "Content-Type": contentType },
-  })
 }

--- a/src/api/dashboard.ts
+++ b/src/api/dashboard.ts
@@ -3,10 +3,33 @@ import type { DashboardResponse } from "./types"
 export async function fetchDashboardCards(): Promise<DashboardResponse> {
   // chama a function da Vercel (mesmo domínio)
   const res = await fetch("/api/cards")
+  const contentType = res.headers.get("content-type") ?? ""
+  const bodyText = await res.text()
+  const isJson = contentType.includes("application/json")
 
   if (!res.ok) {
-    throw new Error(`Erro ao buscar dashboard: HTTP ${res.status}`)
+    let details = ""
+
+    if (isJson) {
+      try {
+        const parsed = JSON.parse(bodyText) as { error?: string }
+        if (parsed?.error) {
+          details = `: ${parsed.error}`
+        }
+      } catch {
+        details = bodyText ? `: ${bodyText.slice(0, 200)}` : ""
+      }
+    } else if (bodyText) {
+      details = `: ${bodyText.slice(0, 200)}`
+    }
+
+    throw new Error(`Erro ao buscar dashboard: HTTP ${res.status}${details}`)
   }
 
-  return (await res.json()) as DashboardResponse
+  if (!isJson) {
+    const preview = bodyText ? `: ${bodyText.slice(0, 200)}` : ""
+    throw new Error(`Resposta inválida do servidor${preview}`)
+  }
+
+  return JSON.parse(bodyText) as DashboardResponse
 }

--- a/src/hooks/useDashboard.ts
+++ b/src/hooks/useDashboard.ts
@@ -21,6 +21,7 @@ export function useDashboard() {
       } catch (e: any) {
         if (!alive) return
         setError(e?.message ?? "Erro desconhecido")
+        setData(null)
       } finally {
         if (!alive) return
         setLoading(false)


### PR DESCRIPTION
### Motivation
- Prevent frontend infinite loading by guaranteeing the Vercel proxy always returns a response and never hangs. 
- Avoid runtime errors from server-only APIs (e.g. `btoa`) and add a timeout for backend requests to fail fast. 
- Surface backend errors and non-JSON responses to the frontend so the hook can stop loading and show clear errors.

### Description
- Update `api/cards.ts` to validate `GET` method, check required env vars, use `Buffer` for Basic Auth, forward query strings, add an `AbortController` timeout (8s), and always return JSON or proxied body with appropriate status codes (502/504/500) on failure. 
- Update `src/api/dashboard.ts` to read response as text, detect `content-type`, avoid calling `res.json()` on HTML, parse JSON only when appropriate, and include backend error details when throwing. 
- Update `src/hooks/useDashboard.ts` to clear `data` on error and ensure `loading` is set to `false` in all code paths while keeping the `alive` cancellation guard.

### Testing
- No automated tests were executed for this change.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_696811c440b4832daf48a1cf43c46b57)